### PR TITLE
Emiia multilang + parler with description quantization config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.wav

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 #.idea/
 
 *.wav
+cache

--- a/configs/quantization/quantization-wav-emilia-multilang.yaml
+++ b/configs/quantization/quantization-wav-emilia-multilang.yaml
@@ -1,0 +1,8 @@
+raw_data: "emilia_multilang"
+prepared_data_path: "emilia_multilang_quantized-wav-uni"
+
+path_to_cache: ".."
+
+quantizer_config_path: "../WavTokenizer/configs/wavtokenizer_smalldata_frame40_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
+quantizer_ckpt_path: "../audiotokenizer/wavtokenizer_large_unify_600_24k.ckpt"
+quantizer_type: "wav"

--- a/configs/quantization/quantization-wav-parler-with-description.yaml
+++ b/configs/quantization/quantization-wav-parler-with-description.yaml
@@ -1,0 +1,8 @@
+raw_data: "parler_tts_with_description"
+prepared_data_path: "parler_tts_with_description_quantized-wav-uni"
+
+path_to_cache: ".."
+
+quantizer_config_path: "../WavTokenizer/configs/wavtokenizer_smalldata_frame40_3s_nq1_code4096_dim512_kmeans200_attn.yaml"
+quantizer_ckpt_path: "../audiotokenizer/wavtokenizer_large_unify_600_24k.ckpt"
+quantizer_type: "wav"

--- a/src/utils/data.py
+++ b/src/utils/data.py
@@ -58,6 +58,8 @@ def prepare_parler_tts_with_description(cache_dir) -> tuple[Dataset, Dataset]:
     audio_features_train = train_audio["audio"]
     audio_features_val = val_audio["audio"]
 
+    os.makedirs("cache/", exist_ok=True)
+
     train_text = train_text.map(
         lambda x, i: {"audio": audio_features_train[i]},
         with_indices=True,


### PR DESCRIPTION
* Конфиг для квантизации на разных языках из emillia `configs/quantization/quantization-wav-emilia-multilang.yaml`
* Конфиг для квантизации parler-with-description `configs/quantization/quantization-wav-parler-with-description.yaml`
* `from src.fish_tokenizer import FishAudioTokenizer` в `prepare_data.py` будет импортироваться только если хотим использовать во время квантизации этот токенайзер - сейчас он не работает и быстро не смог починить. Там че-то знатно порефакторили в fish-audio. Лучше просто узнать , с какого коммита раньше запускались экспы и зафиксировать эту версию для fish tokenizer'а
